### PR TITLE
Include missing header `utility` in tomlcpp.hpp

### DIFF
--- a/tomlcpp.hpp
+++ b/tomlcpp.hpp
@@ -27,6 +27,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 struct toml_table_t;


### PR DESCRIPTION
Without `utility` header, the compiler does not find the definition of `std::pair` and refuses to compile in stricter systems like NixOS.

Closes https://github.com/cktan/tomlcpp/issues/3