### PR TITLE
Use implicit $AR variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ all: $(LIB) $(LIB_SHARED) $(EXEC)
 *.o: $(HFILES)
 
 libtomlcpp.a: $(OBJ)
-	ar -rcs $@ $^
+	$(AR) -rcs $@ $^
 
 libtomlcpp.so: $(OBJ)
 	$(CXX) $(CXXFLAGS) -shared -o $@ $^


### PR DESCRIPTION
According to the documentation[1] this variable defaults to "ar" already. This allows for the variable to be overriden from outside, which is used in cross-compilation.

[1]: https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html#Implicit-Variables